### PR TITLE
add link to license and issues badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **PassWall Server** is the core backend for open source password manager PassWall platform. Using this server, you can safely store your passwords and access them from anywhere. 
 
-![GitHub](https://img.shields.io/github/license/pass-wall/passwall-server)
-![GitHub issues](https://img.shields.io/github/issues/pass-wall/passwall-server)
+[![License](https://img.shields.io/github/license/pass-wall/passwall-server)](https://github.com/pass-wall/passwall-server/blob/master/LICENSE)
+[![GitHub issues](https://img.shields.io/github/issues/pass-wall/passwall-server)](https://github.com/pass-wall/passwall-server/issues)
 [![Build Status](https://travis-ci.org/pass-wall/passwall-server.svg?branch=master)](https://travis-ci.org/pass-wall/passwall-server) 
 [![Coverage Status](https://coveralls.io/repos/github/pass-wall/passwall-server/badge.svg?branch=master)](https://coveralls.io/github/pass-wall/passwall-server?branch=master)
 [![Docker Pull Status](https://img.shields.io/docker/pulls/passwall/passwall-server)](https://hub.docker.com/u/passwall/)  


### PR DESCRIPTION
It is annoying and counter-intuitive that clicking on the issues badge opens up the image instead of the issues page :)