### PR TITLE
fixed: twice request logs

### DIFF
--- a/cmd/passwall-server/main.go
+++ b/cmd/passwall-server/main.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"log"
+	"net/http"
+	"os"
+
 	_ "github.com/heroku/x/hmetrics/onload"
 	"github.com/pass-wall/passwall-server/internal/api"
 	"github.com/pass-wall/passwall-server/internal/config"
@@ -16,8 +20,8 @@ func init() {
 }
 
 func main() {
-
-	n := api.Router()
-	n.Run(":" + viper.GetString("server.port"))
-
+	addr := ":" + viper.GetString("server.port")
+	l := log.New(os.Stdout, "[passwall-server] ", 0)
+	l.Printf("listening on %s", addr)
+	l.Fatal(http.ListenAndServe(addr, api.Router()))
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -10,13 +10,14 @@ import (
 )
 
 // Router ...
-func Router() *negroni.Negroni {
+func Router() *mux.Router {
 
 	db := storage.GetDB()
 	loginAPI := InitLoginAPI(db)
 
 	router := mux.NewRouter()
 	n := negroni.Classic()
+	n.Use(negroni.HandlerFunc(middleware.CORS))
 
 	loginRouter := mux.NewRouter().PathPrefix("/api").Subrouter()
 	loginRouter.HandleFunc("/logins", loginAPI.FindAll).Methods("GET")
@@ -41,10 +42,7 @@ func Router() *negroni.Negroni {
 		negroni.Wrap(authRouter),
 	))
 
-	n.Use(negroni.HandlerFunc(middleware.CORS))
-	n.UseHandler(router)
-
-	return n
+	return router
 }
 
 // InitLoginAPI ..


### PR DESCRIPTION
fixed: [#86](https://github.com/pass-wall/passwall-server/issues/86)

this issue is due to nested usage of negroni.Wrap()

first usage at subrouters:

[goto](https://github.com/pass-wall/passwall-server/blob/7a94131bce9c1db4b832afb4abbc8e473e737523/internal/api/router.go#L35)

	router.PathPrefix("/api").Handler(n.With(
		negroni.HandlerFunc(middleware.Auth),
		negroni.Wrap(loginRouter),
	))

	router.PathPrefix("/auth").Handler(n.With(
		negroni.Wrap(authRouter),
	))

second usage:

[goto](https://github.com/urfave/negroni/blob/f4316798d5d3acd39eb6784301b19f27f471415f/negroni.go#L126)

	func (n *Negroni) UseHandler(handler http.Handler) {
		n.Use(Wrap(handler))
	}

i think one of these should be removed to fix this issue.
i chose to remove UseHandler()
